### PR TITLE
Simplify deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,4 @@ jobs:
                 exit 0
               fi
 
-              ssh -i ~/.ssh/id_rsa_5c082f6f7c65918ed76f034bb3022f7f -o StrictHostKeyChecking=no -p 14815 u_blackpoint@main.blackpoint.co "cd ~/3wurl && git fetch --all && git reset --hard origin/master && bash deploy.sh"
+              ssh -i ~/.ssh/id_rsa_5c082f6f7c65918ed76f034bb3022f7f -o StrictHostKeyChecking=no -p 14815 u_blackpoint@main.blackpoint.co "bash deploy.sh"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+source ~/.bashrc
 git fetch --all
 git reset --hard origin/master
 swift package resolve


### PR DESCRIPTION
Deploy script always sources `~/.bashrc`, and redundant steps from the circle config have been removed.