### PR TITLE
Fix deploy by setting path in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-source ~/.bashrc
+# setup the path
+PATH="$PATH:/usr/local/bin/swift/usr/bin"
+
+# download the code
 git fetch --all
 git reset --hard origin/master
+
+# compile and run
 swift package resolve
 swift build -c release
 sudo service banterurl restart


### PR DESCRIPTION
Now we set the path within the deploy script itself, so that Swift is actually usable.